### PR TITLE
fix(footer): correct spelling of Contour Farming

### DIFF
--- a/jalwiki_ui/components/footer.tsx
+++ b/jalwiki_ui/components/footer.tsx
@@ -50,7 +50,7 @@ export function Footer() {
               </li>
               <li>
                 <Link href="https://jalwiki.vercel.app/techniques/contour-farming" className={`${darkMode ? 'hover:text-white' : 'hover:text-gray-900'}`}>
-                  Counter Farming
+                  Contour Farming
                 </Link>
               </li>
               <li>


### PR DESCRIPTION
## 📝 Description
Corrected a typo in the website footer. Changed "Counter Farming" to its correct spelling, "Contour Farming".

## 🔗 Related Issue
N/A

## 🔄 Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] ⚡ Performance improvement

## 🧪 Testing
- [x] I have performed a self-review of my code
- [x] Code has been tested locally
- [ ] Tests pass (if applicable)
- [x] No new warnings introduced

## 📱 Frontend Changes (if applicable)
- [x] Responsive design tested
- [x] Cross-browser compatibility checked
- [x] Accessibility guidelines followed

## 🔧 Backend Changes (if applicable)
N/A

## 📸 Screenshots/Demo
Here is the corrected spelling in the footer:
<img width="1345" height="630" alt="previous image" src="https://github.com/user-attachments/assets/eb6199f2-4241-4c7a-ac07-f53fc4241988" />
<img width="1358" height="628" alt="fixed img" src="https://github.com/user-attachments/assets/c38f0a0e-15d9-45aa-8475-58d03f0a6160" />


## 📋 Additional Notes
This is my first contribution to the project.

## ✅ Checklist
- [x] My code follows the project's coding standards
- [ ] I have updated documentation where necessary
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works